### PR TITLE
bash: Add examples for "< <()" and "<<<"

### DIFF
--- a/bash.md
+++ b/bash.md
@@ -649,6 +649,8 @@ python hello.py &>/dev/null    # stdout and stderr to (null)
 
 ```bash
 python hello.py < foo.txt      # feed foo.txt to stdin for python
+python hello.py < <( cmd )     # feed stdout from cmd to python
+python hello.py <<< "input"    # feed "input" to stdin for python
 ```
 
 ### Inspecting commands


### PR DESCRIPTION
Credit to Sergiy Kolodyazhnyy ( https://askubuntu.com/a/678919)

Add examples to the Redirection block for the "< <()" and "<<<" use cases.

Testing example:

```
$ echo $BASH_VERSION
3.2.57(1)-release
$ cat hello.py 
#!/usr/bin/python
import sys
for line in sys.stdin:
    print( line )
$ echo "asdf" | python hello.py 
asdf
$ python hello.py <<< "asdf"
asdf
$ python hello.py < <( echo "asdf" )
asdf

```
